### PR TITLE
Add Keycloak integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,33 @@ To deploy these demo projects to your server, run:
 
 *NOTE: These demo projects can take a while to create.*
 
+Keycloak SSO
+------------
+
+This compose file includes an optional **Keycloak** service. It is started on
+port `8080` and uses its own PostgreSQL instance. The default administrator
+credentials are `admin` / `changeme`.
+
+### Example Keycloak setup
+
+1. Browse to `http://localhost:8080` and log in as the Keycloak admin.
+2. Create a realm (for example `ayon`).
+3. Under that realm create a new *client* named `ayon` with `confidential`
+   access type. Set the redirect URI to `http://localhost:5000/*` and save the
+   generated client secret.
+
+### Enabling SSO in Ayon
+
+Set the following variables in the `server` service (they are already present
+in the compose file):
+
+```yaml
+  KEYCLOAK_CLIENT_ID: ayon
+  KEYCLOAK_CLIENT_SECRET: <secret from Keycloak>
+  KEYCLOAK_ISSUER_URL: http://keycloak:8080/realms/ayon
+```
+
+After updating the values run `docker compose up -d` again. On restart the
+frontend will offer a "Login with Keycloak" option and the backend will accept
+tokens issued by the configured realm.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,39 @@ services:
 
     expose: [6379]
 
+  keycloak-db:
+    image: postgres:${KEYCLOAK_DB_TAG:-15}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U keycloak"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    environment:
+      - "POSTGRES_USER=keycloak"
+      - "POSTGRES_PASSWORD=keycloak"
+      - "POSTGRES_DB=keycloak"
+    volumes:
+      - "keycloak-db:/var/lib/postgresql/data"
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:latest
+    command: start-dev
+    restart: unless-stopped
+    depends_on:
+      keycloak-db:
+        condition: service_healthy
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=changeme
+      - KC_DB=postgres
+      - KC_DB_URL_HOST=keycloak-db
+      - KC_DB_URL_DATABASE=keycloak
+      - KC_DB_USERNAME=keycloak
+      - KC_DB_PASSWORD=keycloak
+    ports:
+      - "8080:8080"
+
 
   server:
     image: ynput/ayon:${AYON_STACK_SERVER_TAG:-latest}
@@ -47,18 +80,22 @@ services:
         condition: service_started
 
     expose: [5000]
-    ports: 
+    ports:
       - ${AYON_STACK_SERVER_PORT:-5000}:5000
 
     volumes:
       - "./addons:/addons"
       - "./storage:/storage"
-
       # comment out the following line on Windows
       - "/etc/localtime:/etc/localtime:ro"
-
       # uncomment the following line if you need to work on the backend code
       # - "./backend:/backend"
 
+    environment:
+      - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-ayon}
+      - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET:-changeme}
+      - KEYCLOAK_ISSUER_URL=${KEYCLOAK_ISSUER_URL:-http://keycloak:8080/realms/ayon}
+
 volumes:
   db: {}
+  keycloak-db: {}


### PR DESCRIPTION
## Summary
- add Keycloak and database services to compose file
- expose server environment vars for Keycloak authentication
- document how to configure SSO with Keycloak

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68415b251034832dba5fe34cd67dfb09