### PR TITLE
Fix Keycloak redirect_uri

### DIFF
--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -85,6 +85,14 @@ const LoginPage = ({ isFirstTime = false }) => {
         return
       }
 
+      // include the redirect URI for the OAuth callback
+      if (providerConfig.redirectKey) {
+        qs.append(
+          providerConfig.redirectKey,
+          `${window.location.origin}/login/${provider}`,
+        )
+      }
+
       setIsLoading(true)
       axios
         .get(providerConfig.callback, { params: qs })


### PR DESCRIPTION
## Summary
- send `redirect_uri` when calling the Keycloak callback

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68416775ab28832d862b9f7a2bf28ae0