### PR TITLE
Improve Keycloak addon resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ Configure the addon via the following environment variables or addon settings:
 
 Set these variables when launching the container or define them in the addon settings page to enable Keycloak authentication.
 
+`KEYCLOAK_URL` must be reachable from inside the AYON container. When running
+Keycloak on the host machine, use `http://host.docker.internal:<port>` on
+Docker Desktop or add an `extra_hosts: ["host.docker.internal:host-gateway"]`
+entry (or your host IP address) when using Linux.
+

--- a/backend/tests/test_keycloak_addon.py
+++ b/backend/tests/test_keycloak_addon.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from ayon_server.helpers.modules import import_module
+from addons.keycloak import package as package_module
+
+# Import KeycloakAddon class from the addon server module
+server_module = import_module(
+    "keycloak_server",
+    "addons/keycloak/1.0.0/server/__init__.py",
+)
+KeycloakAddon = server_module.KeycloakAddon
+KeycloakSettings = server_module.KeycloakSettings
+
+
+def build_app():
+    app = FastAPI()
+    addon = KeycloakAddon(
+        definition=type("Def", (), {"friendly_name": "Keycloak"})(),
+        addon_dir="addons/keycloak/1.0.0",
+        name=package_module.name,
+        version=package_module.version,
+    )
+    addon.setup()
+    for router in addon.routers:
+        app.include_router(router, prefix=f"/api/addons/{addon.name}/{addon.version}")
+    return app, addon
+
+
+def test_callback_returns_502_on_connection_error():
+    app, addon = build_app()
+    addon.get_studio_settings = AsyncMock(
+        return_value=KeycloakSettings(
+            url="http://localhost:1",
+            realm="test",
+            client_id="id",
+            client_secret="secret",
+        )
+    )
+    with patch("keycloak_server.httpx.AsyncClient.post", side_effect=server_module.httpx.ConnectError("fail")):
+        client = TestClient(app)
+        resp = client.get(
+            "/api/addons/keycloak/1.0.0/auth/keycloak/callback",
+            params={"code": "x", "redirect_uri": "http://app"},
+        )
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "Keycloak server unreachable"

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -16,7 +16,6 @@ import remarkGfm from 'remark-gfm'
 const clearQueryParams = () => {
   const url = new URL(window.location)
   url.search = ''
-  console.log('clearQueryParams', url.href)
   history.pushState({}, '', url.href)
 }
 
@@ -83,6 +82,14 @@ const LoginPage = ({ isFirstTime = false }) => {
 
       if (!providerConfig) {
         return
+      }
+
+      // include the redirect URI for the OAuth callback
+      if (providerConfig.redirectKey) {
+        qs.append(
+          providerConfig.redirectKey,
+          `${window.location.origin}/login/${provider}`,
+        )
       }
 
       setIsLoading(true)


### PR DESCRIPTION
## Summary
- handle connection errors from Keycloak with a 502
- explain container‑accessible Keycloak URL requirement
- drop leftover console log in LoginPage
- add regression test for failed Keycloak connection

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68416775ab28832d862b9f7a2bf28ae0