### PR TITLE
Enable email-based login

### DIFF
--- a/backend/api/auth/auth.py
+++ b/backend/api/auth/auth.py
@@ -5,22 +5,30 @@
 """
 
 from fastapi import Request
+from typing import Any
 
 from ayon_server.api.dependencies import AccessToken
 from ayon_server.auth.models import LoginResponseModel, LogoutResponseModel
 from ayon_server.auth.password import PasswordAuth
 from ayon_server.auth.session import Session
 from ayon_server.types import Field, OPModel
+from pydantic import root_validator
 
 from .router import router
 
 
 class LoginRequestModel(OPModel):
-    name: str = Field(
-        ...,
+    name: str | None = Field(
+        None,
         title="User name",
         description="Username",
         example="admin",
+    )
+    email: str | None = Field(
+        None,
+        title="Email",
+        description="Email address",
+        example="user@example.com",
     )
     password: str = Field(
         ...,
@@ -28,6 +36,12 @@ class LoginRequestModel(OPModel):
         description="Password",
         example="SecretPassword.123",
     )
+
+    @root_validator(pre=True)
+    def _check_identifier(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if not values.get("name") and not values.get("email"):
+            raise ValueError("Either name or email must be provided")
+        return values
 
 
 @router.post("/login")
@@ -44,7 +58,13 @@ async def login(request: Request, login: LoginRequestModel) -> LoginResponseMode
     Returns 401 response if the credentials are invalid.
     """
 
-    session = await PasswordAuth.login(login.name, login.password, request)
+    identifier = login.name or login.email or ""
+    session = await PasswordAuth.login(
+        identifier,
+        login.password,
+        request,
+        email=login.email,
+    )
 
     return LoginResponseModel(
         detail=f"Logged in as {session.user.name}",

--- a/backend/ayon_server/types.py
+++ b/backend/ayon_server/types.py
@@ -73,8 +73,9 @@ NAME_REGEX = r"^[a-zA-Z0-9_]([a-zA-Z0-9_\.\-]*[a-zA-Z0-9_])?$"
 STATUS_REGEX = r"^[a-zA-Z0-9_][a-zA-Z0-9_ \-]{1,64}[a-zA-Z0-9_]$"
 TYPE_NAME_REGEX = r"^[a-zA-Z0-9_][a-zA-Z0-9_ \-]{1,64}[a-zA-Z0-9_]$"
 
-# user names shouldn't start or end with underscores
-USER_NAME_REGEX = r"^[a-zA-Z0-9][a-zA-Z0-9_\.\-]*[a-zA-Z0-9]$"
+# user names shouldn't start or end with spaces or special characters
+# allow spaces and '@' inside the name
+USER_NAME_REGEX = r"^[a-zA-Z0-9][a-zA-Z0-9_.@\- ]*[a-zA-Z0-9]$"
 
 # project name cannot contain - / . (sql hard limit for schema names)
 PROJECT_NAME_REGEX = r"^[a-zA-Z0-9_]*$"
@@ -98,6 +99,7 @@ def validate_name(name: str, regex: str = NAME_REGEX) -> str:
 
 def validate_user_name(name: str) -> str:
     """Validate user name."""
+    name = name.strip()
     if not re.match(USER_NAME_REGEX, name):
         raise BadRequestException(
             f"User name '{name}' does not match regex '{USER_NAME_REGEX}'"

--- a/frontend/shared/src/api/generated/authentication.ts
+++ b/frontend/shared/src/api/generated/authentication.ts
@@ -78,7 +78,9 @@ export type HttpValidationError = {
 }
 export type LoginRequestModel = {
   /** Username */
-  name: string
+  name?: string
+  /** Email address */
+  email?: string
   /** Password */
   password: string
 }


### PR DESCRIPTION
## Summary
- expand username regex for spaces and `@`
- support email in LoginRequestModel and validation
- look up users by email in password login
- update generated authentication TypeScript file

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684914c83a6c832db9266858a705e1af