### PR TITLE
Allow login via email

### DIFF
--- a/backend/ayon_server/auth/password.py
+++ b/backend/ayon_server/auth/password.py
@@ -81,12 +81,14 @@ class PasswordAuth:
         if email is None and "@" in identifier:
             email = identifier
 
+        result = None
         if email:
             result = await Postgres.fetch(
-                "SELECT * FROM public.users WHERE LOWER(attrib->>'email') = $1",
-                email.lower(),
+                "SELECT * FROM public.users WHERE LOWER(attrib->>'email') = LOWER($1)",
+                email,
             )
-        else:
+
+        if not result:
             result = await Postgres.fetch(
                 "SELECT * FROM public.users WHERE name ilike $1",
                 identifier,

--- a/frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage/LoginPage.jsx
@@ -23,7 +23,7 @@ const LoginPage = ({ isFirstTime = false }) => {
   // get query params from url
   const search = new URLSearchParams(window.location.search)
   const dispatch = useDispatch()
-  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
 
   // which methods are featured (all others are hidden)
@@ -137,7 +137,7 @@ const LoginPage = ({ isFirstTime = false }) => {
 
   const doLogin = async () => {
     axios
-      .post('/api/auth/login', { name, password })
+      .post('/api/auth/login', { email, password })
       .then((response) => {
         if (response.data.user) {
           // clear local storage
@@ -161,8 +161,8 @@ const LoginPage = ({ isFirstTime = false }) => {
   const handleSubmit = (e) => {
     e.preventDefault()
 
-    if (!(name && password)) {
-      toast.error('Please enter username and password to login')
+    if (!(email && password)) {
+      toast.error('Please enter email and password to login')
     } else {
       doLogin()
     }
@@ -188,14 +188,14 @@ const LoginPage = ({ isFirstTime = false }) => {
           <Styled.Methods>
             {showPasswordLogin && (
               <form onSubmit={handleSubmit}>
-                <label id="username">Username</label>
+                <label id="email">Email</label>
                 <InputText
                   autoFocus
-                  placeholder="Enter your username"
-                  name="username"
-                  aria-label="Username"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Enter your email"
+                  name="email"
+                  aria-label="Email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
                 />
                 <label id="password">Password</label>
                 <InputPassword


### PR DESCRIPTION
## Summary
- support email lookup in password auth fallback to name
- prompt for email on frontend login page

## Testing
- `uv run pre-commit run --files ../backend/api/auth/auth.py ayon_server/auth/password.py` *(fails: error sending request)*
- `yarn lint src/pages/LoginPage/LoginPage.jsx` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684915e94380832d9860eaa0b19d8ace